### PR TITLE
Changed the name that displays in Mod Menu and.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "scarpet-additions",
   "version": "${version}",
 
-  "name": "scarpet-additions",
+  "name": "Scarpet Additions",
   "description": "Adds a couple scarpet functions",
   "authors": [
     "replaceitem"


### PR DESCRIPTION
Changed the name that displays in Mod Menu, because all other mods start with capital letters, and this one looked ugly, also, for some reason either the lowercase letters or the hyphen put it at the bottom of the list, therefore putting it below World Edit etc, so it broke alphabetical order. I tested on current version by changing the jar file with 7zip, and it displays much more nicely in Mod Menu. I don't want to have to edit this every time for every version, so I am proposing this change.